### PR TITLE
Add Store Engagement NuGet package reference

### DIFF
--- a/Baconit/Baconit.csproj
+++ b/Baconit/Baconit.csproj
@@ -549,6 +549,9 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.11</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Services.Store.Engagement">
+      <Version>10.1901.28001</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Services.Store.SDK">
       <Version>10.1705.16001</Version>
     </PackageReference>

--- a/Baconit/Baconit.csproj
+++ b/Baconit/Baconit.csproj
@@ -532,9 +532,6 @@
     <XliffResource Include="MultilingualResources\Baconit.pt-BR.xlf" />
   </ItemGroup>
   <ItemGroup>
-    <SDKReference Include="Microsoft.Services.Store.Engagement, Version=10.0">
-      <Name>Microsoft Engagement Framework</Name>
-    </SDKReference>
     <SDKReference Include="Microsoft.VCLibs, Version=14.0">
       <Name>Visual C++ 2015 Runtime for Universal Windows Platform Apps</Name>
     </SDKReference>


### PR DESCRIPTION
The Store Services SDK ships in both VSIX and NuGet forms. Installing the VSIX is no longer recommended and slows down developer onboarding, so we introduce a NuGet package reference instead.